### PR TITLE
ci: dependency-submission braucht contents: write

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -10,6 +10,9 @@ concurrency:
   group: '${{ github.workflow }}: ${{ github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   dependency-submission:
     name: Dependency Submission


### PR DESCRIPTION
Bereitet das Repo auf die geplante Org-Umstellung des Standard-GITHUB_TOKEN auf read-only vor.

Der dependency-submission-Workflow sendet einen Dependency-Graph-Snapshot an die GitHub-API; das benoetigt contents: write. Ohne expliziten permissions-Block schlaegt der Job nach der Umstellung mit HTTP 403 fehl und die Dependency-Graph-Einspeisung (Basis fuer Dependabot) bricht ab.

Aenderung: workflow-weiter permissions-Block (contents: write) ergaenzt, gleiches Muster wie bereits in perils-platform / perils-workspace.

Teil des GitHub-Security-Audits.